### PR TITLE
Handling unknown system theme

### DIFF
--- a/lib/flutter_flatpak.dart
+++ b/lib/flutter_flatpak.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 
 class Flatpak {
   /// The system's theme preference, light or dark.
-  final ThemeMode themeMode;
+  /// `null` if if the theme is unknown or
+  /// the system does not support this feature.
+  final ThemeMode? themeMode;
 
   const Flatpak._({
     required this.themeMode,
@@ -22,7 +24,9 @@ class Flatpak {
   }
 
   /// Since Flatpak is in a sandbox we get theme preference from dbus.
-  static Future<ThemeMode> _systemThemeMode() async {
+  /// Returns `null` if if the theme is unknown or
+  /// the system does not support this feature.
+  static Future<ThemeMode?> _systemThemeMode() async {
     final result = await Process.run('bash', [
       '-c',
       "dbus-send --print-reply --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' string:'color-scheme'"
@@ -30,11 +34,13 @@ class Flatpak {
 
     final themeNumber = (result.stdout as String).trim().split('').last;
 
-    ThemeMode themeMode;
+    ThemeMode? themeMode;
     if (themeNumber == '2') {
       themeMode = ThemeMode.light;
-    } else {
+    } else if (themeNumber == '1') {
       themeMode = ThemeMode.dark;
+    } else {
+      themeMode = null;
     }
 
     return themeMode;


### PR DESCRIPTION
The [Portal specification](https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Settings) tells us:
>Supported values are:
>
>0: No preference
>1: Prefer dark appearance
>2: Prefer light appearance
>
>Unknown values should be treated as 0 (no preference).

Some systems, such as Fedora 36, returns `0` if we have a light theme set. The plugin assumes that this case is a dark theme by default, although it would be more correct to return `null`, because the real value isn't available to us. In this case, the developer, who uses the plugin, is free to decide which theme to use in this case.

Close #1